### PR TITLE
Fix Product domain class source code in guide

### DIFF
--- a/src/main/docs/guide/domainClass.adoc
+++ b/src/main/docs/guide/domainClass.adoc
@@ -16,14 +16,7 @@ A domain class is a simple Groovy class and you can represent each column of a t
 [source,groovy]
 .grails-app/domain/hibernate/example/Product.groovy
 ----
-package hibernate.example
-
-import grails.compiler.GrailsCompileStatic
-
-@GrailsCompileStatic
-class Product {
-    String name
-    Double price
+include::{sourceDir}/grails-app/domain/hibernate/example/Product.groovy[indent=0,lines="1..9"]
 }
 ----
 

--- a/src/main/docs/guide/domainClass.adoc
+++ b/src/main/docs/guide/domainClass.adoc
@@ -16,7 +16,14 @@ A domain class is a simple Groovy class and you can represent each column of a t
 [source,groovy]
 .grails-app/domain/hibernate/example/Product.groovy
 ----
-include::{sourceDir}/grails-app/domain/hibernate/example/Product.groovy[indent=0,lines="1..6"]
+package hibernate.example
+
+import grails.compiler.GrailsCompileStatic
+
+@GrailsCompileStatic
+class Product {
+    String name
+    Double price
 }
 ----
 


### PR DESCRIPTION
The guide currently does not display everything that's needed from the Product domain class. This patch here should fix it.